### PR TITLE
Jenkins pipeline support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.11</version>
+        <version>3.24</version>
         <relativePath />
     </parent>
     <artifactId>opsgenie</artifactId>
@@ -16,10 +16,8 @@
     <url>https://wiki.jenkins.io/display/JENKINS/OpsGenie+Plugin</url>
 
     <properties>
-        <jetty.version>9.2.15.v20160210</jetty.version>
-        <jenkins.version>1.625.3</jenkins.version>
-        <java.level>7</java.level>
-        <jenkins-test-harness.version>2.1</jenkins-test-harness.version>
+        <jenkins.version>2.121.1</jenkins.version>
+        <java.level>8</java.level>
     </properties>
 
     <licenses>
@@ -102,7 +100,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.2</version>
+            <version>4.5.6</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -110,74 +108,5 @@
             <version>1.9</version>
             <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-test-harness</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-io</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-util</artifactId>
-                </exclusion>
-            </exclusions>
-            <version>2.22</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-test-harness-htmlunit</artifactId>
-            <version>2.18-1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-io</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-util</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.4</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-server</artifactId>
-            <version>${jetty.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-security</artifactId>
-            <version>${jetty.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlet</artifactId>
-            <version>${jetty.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-util</artifactId>
-            <version>${jetty.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-io</artifactId>
-            <version>${jetty.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
-
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -108,5 +108,10 @@
             <version>1.9</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-step-api</artifactId>
+            <version>2.16</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/opsgenie/integration/jenkins/OpsGenieNotificationRequest.java
+++ b/src/main/java/com/opsgenie/integration/jenkins/OpsGenieNotificationRequest.java
@@ -1,7 +1,7 @@
 package com.opsgenie.integration.jenkins;
 
-import hudson.model.AbstractBuild;
-import hudson.model.BuildListener;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 
 /**
  * @author Omer Ozkan
@@ -14,8 +14,8 @@ public class OpsGenieNotificationRequest {
     private String apiKey;
     private String apiUrl;
     private AlertProperties alertProperties;
-    private AbstractBuild build;
-    private BuildListener listener;
+    private Run<?, ?> build;
+    private TaskListener listener;
 
     public String getApiKey() {
         return apiKey;
@@ -44,20 +44,20 @@ public class OpsGenieNotificationRequest {
         return this;
     }
 
-    public AbstractBuild getBuild() {
+    public Run<?, ?> getBuild() {
         return build;
     }
 
-    public OpsGenieNotificationRequest setBuild(AbstractBuild build) {
+    public OpsGenieNotificationRequest setBuild(Run<?, ?> build) {
         this.build = build;
         return this;
     }
 
-    public BuildListener getListener() {
+    public TaskListener getListener() {
         return listener;
     }
 
-    public OpsGenieNotificationRequest setListener(BuildListener listener) {
+    public OpsGenieNotificationRequest setListener(TaskListener listener) {
         this.listener = listener;
         return this;
     }

--- a/src/main/java/com/opsgenie/integration/jenkins/pipeline/OpsGenieTriggerStep.java
+++ b/src/main/java/com/opsgenie/integration/jenkins/pipeline/OpsGenieTriggerStep.java
@@ -1,0 +1,171 @@
+package com.opsgenie.integration.jenkins.pipeline;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+
+import com.opsgenie.integration.jenkins.AlertPriority;
+import com.opsgenie.integration.jenkins.AlertProperties;
+import com.opsgenie.integration.jenkins.OpsGenieNotificationRequest;
+import com.opsgenie.integration.jenkins.OpsGenieNotificationService;
+import com.opsgenie.integration.jenkins.OpsGenieNotifier;
+
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.Util;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import jenkins.model.Jenkins;
+
+public class OpsGenieTriggerStep extends AbstractStepImpl {
+
+    @Nonnull
+    private boolean enable;
+    private boolean notifyBuildStart;
+    private String tags;
+    private String apiKey;
+    private String apiUrl;
+    private String teams;
+    private String priority;
+    private String buildStartPriority;
+
+    public boolean getEnable() {
+        return this.enable;
+    }
+
+    @DataBoundSetter
+    public void setEnable(boolean enable) {
+        this.enable = enable;
+    }
+
+    public boolean getNotifyBuildStart() {
+        return this.notifyBuildStart;
+    }
+
+    @DataBoundSetter
+    public void setNotifyBuildStart(boolean notifyBuildStart) {
+        this.notifyBuildStart = notifyBuildStart;
+    }
+
+    @DataBoundSetter
+    public void setTags(String tags) {
+        this.tags = tags;
+    }
+
+    @DataBoundSetter
+    public void setTeams(String teams) {
+        this.teams = teams;
+    }
+
+    public String getTags() {
+        return tags;
+    }
+
+    public String getTeams() {
+        return teams;
+    }
+
+    public String getPriority() {
+        return priority;
+    }
+
+    @DataBoundSetter
+    public void setPriority(String priority) {
+        this.priority = priority;
+    }
+
+    public String getBuildStartPriority() {
+        return buildStartPriority;
+    }
+
+    @DataBoundSetter
+    public void setBuildStartPriority(String buildStartPriority) {
+        this.buildStartPriority = buildStartPriority;
+    }
+
+    @DataBoundConstructor
+    public OpsGenieTriggerStep() {
+    }
+
+    @Extension
+    public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+        public DescriptorImpl() {
+            super(OpsGenieTriggerStepExecution.class);
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "opsgenie";
+        }
+
+        @Nonnull
+
+        @Override
+        public String getDisplayName() {
+            return "OpsGenie step";
+        }
+    }
+
+    public static class OpsGenieTriggerStepExecution extends AbstractSynchronousNonBlockingStepExecution<String> {
+
+        private static final long serialVersionUID = 1L;
+
+        @Inject
+        transient OpsGenieTriggerStep step;
+
+        @StepContextParameter
+        transient TaskListener listener;
+
+        @StepContextParameter
+        private transient Run<?, ?> build;
+
+        @StepContextParameter
+        private transient Launcher launcher;
+
+        @Override
+        protected String run() throws Exception {
+            // default to global config values if not set in step, but allow step to
+            // override all global settings
+            Jenkins jenkins;
+            try {
+                jenkins = Jenkins.getInstance();
+            } catch (NullPointerException ne) {
+                listener.error("ERROR?!");
+                return null;
+            }
+            OpsGenieNotifier.DescriptorImpl ogDesc = jenkins.getDescriptorByType(OpsGenieNotifier.DescriptorImpl.class);
+
+            // OpsGenieNotifier notifier = new OpsGenieNotifier(step.enable,
+            // step.notifyBuildStart, step.tags, step.apiKey,
+            // step.apiUrl, step.teams, step.priority, step.buildStartPriority);
+            // notifier.perform(build, null, (BuildListener) listener);
+
+            // This variables for override the fields if they are not empty
+            String tagsGiven = Util.fixNull(step.tags).isEmpty() ? ogDesc.getTags() : step.tags;
+            String teamsGiven = Util.fixNull(step.teams).isEmpty() ? ogDesc.getTeams() : step.teams;
+
+            AlertPriority alertPriority = AlertPriority.fromDisplayName(step.priority);
+            AlertPriority notifyBuildStartPriority = AlertPriority.fromDisplayName(step.buildStartPriority);
+            AlertProperties alertProperties = new AlertProperties().setTags(tagsGiven).setTeams(teamsGiven)
+                    .setPriority(alertPriority).setBuildStartPriority(notifyBuildStartPriority);
+
+            String apiKeyGiven = Util.fixNull(step.apiKey).isEmpty() ? ogDesc.getApiKey() : step.apiKey;
+            String apiUrlGiven = Util.fixNull(step.apiUrl).isEmpty() ? ogDesc.getApiUrl() : step.apiUrl;
+
+            OpsGenieNotificationRequest request = new OpsGenieNotificationRequest().setAlertProperties(alertProperties)
+                    .setBuild(build).setListener(listener).setApiKey(apiKeyGiven).setApiUrl(apiUrlGiven);
+
+            OpsGenieNotificationService ogService = new OpsGenieNotificationService(request);
+            ogService.sendAfterBuildData();
+
+            return null;
+        }
+
+    }
+}


### PR DESCRIPTION
Tried to avoid changing the older code too much, but needed to convert AbstractBuild -> Run, AbstractProject -> Job, and BuildListener -> TaskListener.

I couldn't figure out how to change the jenkins version to something lower without a compatibility issue with the pipeline plugin when I was testing.  It probably also needs a major version bump although non-pipeline jobs still work.