### PR TITLE
Use project's full name to provide sensible names in OpsGenie alerts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,13 +43,13 @@
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
 

--- a/src/main/java/com/opsgenie/integration/jenkins/OpsGenieNotificationService.java
+++ b/src/main/java/com/opsgenie/integration/jenkins/OpsGenieNotificationService.java
@@ -222,7 +222,7 @@ public class OpsGenieNotificationService {
             }
             Job<?, ?> previousProject = previousBuild.getParent();
             if (previousProject != null) {
-                String previousProjectName = previousProject.getName();
+                String previousProjectName = previousProject.getFullName();
                 requestPayload.put("previousProjectName", previousProjectName);
             }
         }
@@ -260,7 +260,7 @@ public class OpsGenieNotificationService {
         String time = Objects.toString(build.getTimestamp().getTime());
         requestPayload.put("time", time);
 
-        String projectName = project.getName();
+        String projectName = project.getFullName();
         requestPayload.put("projectName", projectName);
 
         String displayName = build.getDisplayName();


### PR DESCRIPTION
Use project's full name to provide sensible names in OpsGenie alert:
![image](https://github.com/user-attachments/assets/0d7ea9cc-f2e6-415e-b297-b6fd6a0f06c2)

Change to HTTPS in repositories block was required by Maven (building tested on Maven 3.6.0 @ Liberica JDK  8.0.422, builds against never JDK and Maven versions are faililing in both my branch and upsteam repository)

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
